### PR TITLE
fix(client): git toggle override

### DIFF
--- a/packages/amplication-client/src/Resource/git/ServiceConfigurationGitSettings.tsx
+++ b/packages/amplication-client/src/Resource/git/ServiceConfigurationGitSettings.tsx
@@ -99,7 +99,7 @@ const ServiceConfigurationGitSettings: React.FC<Props> = ({
     [resource.id, trackEvent, updateResourceOverrideStatus]
   );
 
-  const isToggleDisable = currentWorkspace?.gitOrganizations?.length === 0;
+  const isToggleDisable = currentWorkspace?.gitOrganizations?.length !== 0;
 
   return (
     <div className={CLASS_NAME}>


### PR DESCRIPTION
the variable isToggleDisable was set to true , which should be false initially 
Close: #[5515]

this solves the problem of -> The override toggle doesn't change when clicked.
now, User can override the project settings and connect to his desired git provider and repo



